### PR TITLE
proper surface matching

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "architecture": "@CLICK_ARCH@",
   "title": "uWolf",
   "hooks": {
-    "uwolf": {
+    "navigator": {
       "apparmor": "uwolf.apparmor",
       "desktop": "uwolf.desktop"
     }


### PR DESCRIPTION
with https://gitlab.com/ubports/development/core/lomiri/-/merge_requests/282 xwayland apps will now no longer have a lingering placeholder

for this the surface name must match the toplevel window name

librewolf's toplevel window name is navigator

this PR sets part of the surface name to navigator to so MR 282 can properly match it